### PR TITLE
Fix for logitech MX devices

### DIFF
--- a/src/virtual_device.py
+++ b/src/virtual_device.py
@@ -13,7 +13,8 @@ def create_virtual_device():
 
         if ("BTN_RIGHT", 273) in keys:
             mouse = input_device
-        elif ("KEY_LEFTMETA", 125) in keys:
+        
+        if ("KEY_LEFTMETA", 125) in keys:
             keyboard = input_device
 
         if mouse and keyboard:


### PR DESCRIPTION
Seems like certain Logitech devices register themselves as both keyboard and mice. My combination of Logitech MX Keys + MX Master 3 register as both `pointer` and `keyboard`. This change allows the script to regsiter both devices as `pointer`.