### PR TITLE
Add delta setting to control movement distance for swipe/scroll activation

### DIFF
--- a/data/mouse-swipe.conf
+++ b/data/mouse-swipe.conf
@@ -3,6 +3,7 @@
 #   - scroll: Button will support vertical and horizontal scroll when pressed.
 #   - freeze: Mouse cursor will not move while button is pressed.
 #   - click: Mapping for mouse click (without movement). If not defined, the default click action will be performed.
+#   - delta: Minimal movement distance to handle swipe/scroll.
 #
 # Notes:
 #   - If using scroll option, the swipe_* options are ignored for that button.

--- a/src/config.py
+++ b/src/config.py
@@ -22,6 +22,7 @@ def read_config_file():
         swipe_button.click = click if (len(click) > 0) else [button]
         swipe_button.freeze = config[button].getboolean("freeze", False)
         swipe_button.scroll = config[button].getboolean("scroll", False)
+        swipe_button.delta = abs(config[button].getint("delta", 10))
         if not(swipe_button.scroll):
             swipe_button.swipe_left = _get_array(config[button].get("swipe_left"))
             swipe_button.swipe_right = _get_array(config[button].get("swipe_right"))

--- a/src/main.py
+++ b/src/main.py
@@ -77,7 +77,7 @@ async def task_handle_mouse_events(mouse):
                     if event.code == ecodes.REL_X:
                         swipe_button.deltaX += event.value
 
-                        if abs(swipe_button.deltaX) > 10 and not(swipe_button.moved):
+                        if abs(swipe_button.deltaX) > swipe_button.delta and not(swipe_button.moved):
                             swipe_button.moved = True
 
                         if swipe_button.scroll and swipe_button.moved:
@@ -85,7 +85,7 @@ async def task_handle_mouse_events(mouse):
                     elif event.code == ecodes.REL_Y:
                         swipe_button.deltaY += event.value
 
-                        if abs(swipe_button.deltaY) > 10 and not(swipe_button.moved):
+                        if abs(swipe_button.deltaY) > swipe_button.delta and not(swipe_button.moved):
                             swipe_button.moved = True
 
                         if swipe_button.scroll and swipe_button.moved:

--- a/src/swipe_button.py
+++ b/src/swipe_button.py
@@ -5,6 +5,7 @@ class SwipeButton:
     
     pressed = 0
     deltaX, deltaY = 0, 0
+    delta = 0
 
     def __init__(self, button):
         self.button = button


### PR DESCRIPTION
I use mice with resolution 1200dpi and default delta `10` is too small to correct handle `click` event. With this PR, users can specific the `delta` value in config file