### PR TITLE
Remove interpreter in mouse-swipe.service

### DIFF
--- a/data/mouse-swipe.service
+++ b/data/mouse-swipe.service
@@ -3,7 +3,7 @@ Description=Swipe gestures support for mouse buttons
 After=display-manager.service
 
 [Service]
-ExecStart=python /usr/local/share/mouse-swipe/main.py
+ExecStart=/usr/local/share/mouse-swipe/main.py
 RemainAfterExit=no
 Restart=on-failure
 RestartSec=5s


### PR DESCRIPTION
Systemd service should execute the script directly instead of calling python


The systemd service currently contains:
```
ExecStart=python /usr/local/share/mouse-swipe/main.py
```
However, main.py already has a proper shebang:
```
#!/usr/bin/python3
```
and is installed as an executable. Therefore, the service can simply use:
```
ExecStart=/usr/local/share/mouse-swipe
```
This is more portable and lets the operating system use the interpreter specified by the shebang.

AFAIK: On openSUSE Tumbleweed (and a number of other modern Linux distributions), the unversioned python executable is intentionally not installed by default. Historically, python could refer to Python 2, and many distributions now require software to explicitly use python3 (or rely on the script's shebang) to avoid ambiguity.

As a result, the current service fails with:
```
Failed at step EXEC spawning python: No such file or directory
```