### PR TITLE
Use mkdir -p in install script to allow repeated installations

### DIFF
--- a/install
+++ b/install
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-cd src && mkdir /usr/local/share/mouse-swipe && cp config.py swipe_button.py main.py mouse.py virtual_device.py /usr/local/share/mouse-swipe
+cd src && mkdir -p /usr/local/share/mouse-swipe && cp config.py swipe_button.py main.py mouse.py virtual_device.py /usr/local/share/mouse-swipe
 cd ../data && cp mouse-swipe.service /etc/systemd/system && cp -u mouse-swipe.conf /etc
 systemctl daemon-reload
 systemctl enable mouse-swipe.service --now


### PR DESCRIPTION
Use mkdir -p when creating the installation directory so the script can be executed multiple times without failing when the directory already exists.

This allows repeated installs during development and upgrades without uninstalling /usr/local/share/mouse-swipe.